### PR TITLE
Bug fix of mutexes in sagas provider

### DIFF
--- a/src/SagasProvider.php
+++ b/src/SagasProvider.php
@@ -377,13 +377,16 @@ final class SagasProvider
     {
         $mutexKey = createMutexKey($id);
 
-        $mutex = $this->mutexFactory->create($mutexKey);
+        if (false === \array_key_exists($mutexKey, $this->lockCollection))
+        {
+            $mutex = $this->mutexFactory->create($mutexKey);
 
-        /**
-         * @psalm-suppress TooManyTemplateParams
-         * @psalm-suppress InvalidPropertyAssignmentValue
-         */
-        $this->lockCollection[$mutexKey] = yield $mutex->acquire();
+            /**
+             * @psalm-suppress TooManyTemplateParams
+             * @psalm-suppress InvalidPropertyAssignmentValue
+             */
+            $this->lockCollection[$mutexKey] = yield $mutex->acquire();
+        }
     }
 
     /**


### PR DESCRIPTION
At the sagas provider before creating a mutex, need to check the existence at lockCollection. If another AmpLock object will be created, then the previous no longer be accessed and it will be impossible to call the release () method